### PR TITLE
fix(audio): boss defeat SFX no longer crashes mobile audio

### DIFF
--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -263,22 +263,31 @@ export default class GameScene extends Phaser.Scene {
     const buttons = this.registry.get('touchButtons');
     if (!buttons) return;
 
+    // Resume audio on any touch gesture — safety net for mobile browsers
+    // that suspend the AudioContext after audio pipeline disruptions.
+    const resumeAudio = () => {
+      const sfx = this.registry.get('sfx');
+      if (sfx) sfx.resume();
+      const audioManager = this.registry.get('audioManager');
+      if (audioManager) audioManager.resume();
+    };
+
     // D-pad
-    buttons.left.addEventListener('touchstart', (e) => { e.preventDefault(); this.touchIntent.left = true; });
+    buttons.left.addEventListener('touchstart', (e) => { e.preventDefault(); resumeAudio(); this.touchIntent.left = true; });
     buttons.left.addEventListener('touchend', () => { this.touchIntent.left = false; });
     buttons.left.addEventListener('touchcancel', () => { this.touchIntent.left = false; });
 
-    buttons.right.addEventListener('touchstart', (e) => { e.preventDefault(); this.touchIntent.right = true; });
+    buttons.right.addEventListener('touchstart', (e) => { e.preventDefault(); resumeAudio(); this.touchIntent.right = true; });
     buttons.right.addEventListener('touchend', () => { this.touchIntent.right = false; });
     buttons.right.addEventListener('touchcancel', () => { this.touchIntent.right = false; });
 
     // Jump — _jumpHeld tracks whether finger is on button (for variable-height jump)
-    buttons.jump.addEventListener('touchstart', (e) => { e.preventDefault(); this.touchIntent.jump = true; this._jumpHeld = true; });
+    buttons.jump.addEventListener('touchstart', (e) => { e.preventDefault(); resumeAudio(); this.touchIntent.jump = true; this._jumpHeld = true; });
     buttons.jump.addEventListener('touchend', () => { this._jumpHeld = false; });
     buttons.jump.addEventListener('touchcancel', () => { this._jumpHeld = false; });
 
     // Net
-    buttons.net.addEventListener('touchstart', (e) => { e.preventDefault(); this.touchIntent.net = true; });
+    buttons.net.addEventListener('touchstart', (e) => { e.preventDefault(); resumeAudio(); this.touchIntent.net = true; });
     buttons.net.addEventListener('touchend', () => {});
     buttons.net.addEventListener('touchcancel', () => {});
   }
@@ -563,9 +572,6 @@ export default class GameScene extends Phaser.Scene {
     this.cameras.main.shake(300, 0.01);
 
     if (this.bossHitsRemaining <= 0) {
-      // Final hit — play defeat SFX immediately here (belt-and-suspenders
-      // with bossDefeated), ensuring it fires regardless of animation state
-      if (sfx) sfx.play('sfx-boss-defeat');
       this.bossDefeated();
     } else {
       // Non-final hit — show damage reaction then restart cycle
@@ -639,10 +645,10 @@ export default class GameScene extends Phaser.Scene {
       if (sfx) sfx.play('victory');
     });
 
-    // Hard-stop music so the COMICALLY LOUD defeat SFX cuts through
+    // Fade out music quickly so the defeat SFX cuts through
     const audioManager = this.registry.get('audioManager');
     if (audioManager) {
-      audioManager.stopMusic(0);
+      audioManager.stopMusic(300);
 
       if (this.levelData.miniBoss) {
         // Mini-boss: resume gameplay music after defeat SFX has had its moment
@@ -828,10 +834,10 @@ export default class GameScene extends Phaser.Scene {
     const sfx = this.registry.get('sfx');
     if (sfx) sfx.play('sfx-boss-defeat');
 
-    // Stop boss music and resume appropriate track
+    // Fade out boss music quickly
     const audioManager = this.registry.get('audioManager');
     if (audioManager) {
-      audioManager.stopMusic(0);
+      audioManager.stopMusic(300);
       if (this.levelData.miniBoss) {
         this.time.delayedCall(1200, () => {
           audioManager.playMusic('theme-gameplay', { volume: 0.35, fadeIn: 800, fadeOut: 0 });

--- a/src/utils/SFX.js
+++ b/src/utils/SFX.js
@@ -24,7 +24,7 @@ export default class SFX {
   static FILE_VOLUMES = {
     'sfx-kitty-defeat': 0.45,   // ~10% quieter than default
     'sfx-net-call': 0.52,       // ~5% quieter than default
-    'sfx-boss-defeat': 2.0,     // COMICALLY LOUD — intentionally clips for comedic effect
+    'sfx-boss-defeat': 0.9,     // Loud but safe for mobile audio pipelines
   };
 
   /**


### PR DESCRIPTION
## Summary

- **Root cause**: `sfx-boss-defeat` was fired twice simultaneously at gain `2.0` each (effective 4.0 / 400% amplitude), overwhelming mobile browsers' audio pipelines and causing the AudioContext to suspend. Immediately after, `stopMusic(0)` hard-killed all HTML5 Audio, leaving both audio systems dead.
- **Symptom**: All sound cut out on boss defeat (no defeat SFX heard), stayed dead until partway through the next stage when a user tap revived the suspended AudioContext.
- Removed duplicate `sfx-boss-defeat` play (was in both `hitBossWithNet()` and `bossDefeated()`)
- Lowered `sfx-boss-defeat` gain from `2.0` to `0.9` — still the loudest SFX, but won't clip/crash mobile audio
- Replaced `stopMusic(0)` hard-kill with `stopMusic(300)` short fade in `bossDefeated()` and `bossGoneFailsafe()`
- Added `resumeAudio()` safety net to all mobile touch handlers so any tap immediately revives a suspended AudioContext

## Test plan

- [ ] Play through Stage 1 on mobile, defeat the mini-boss — verify defeat SFX plays and gameplay music resumes
- [ ] Play through Stage 2 on mobile, defeat the mini-boss — same verification
- [ ] Play through Stage 3 on mobile, defeat the final boss — verify defeat SFX plays and sound continues into victory sequence
- [ ] Verify no audio dropout between stages on mobile
- [ ] Verify desktop audio still works correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)